### PR TITLE
Fix stock transaction logic for waste management

### DIFF
--- a/app/Http/Controllers/Admin/PenjualanSampahController.php
+++ b/app/Http/Controllers/Admin/PenjualanSampahController.php
@@ -77,14 +77,8 @@ class PenjualanSampahController extends Controller
     {
         $pengepuls = Pengepul::all();
         $sampahs = Sampah::with(['jenisSampah'])
-            ->select('id', 'nama_sampah', 'jenis_sampah_id', 'harga_per_kg')
-            ->withSum('setoranDetails', 'berat')
-            ->withSum('penjualanSampahs', 'berat')
-            ->get()
-            ->map(function ($sampah) {
-                $sampah->stok = ($sampah->setoran_details_sum_berat ?? 0) - ($sampah->penjualan_sampahs_sum_berat ?? 0);
-                return $sampah;
-            });
+            ->select('id', 'nama_sampah', 'jenis_sampah_id', 'harga_per_kg', 'stok')
+            ->get();
 
         return view('admin.transaksi.penjualan-sampah.create', compact('pengepuls', 'sampahs'));
     }
@@ -98,6 +92,25 @@ class PenjualanSampahController extends Controller
             'berat' => 'required|array',
             'berat.*' => 'required|numeric|min:0.1',
         ]);
+
+        $errors = [];
+        foreach ($request->sampah_id as $index => $sampahId) {
+            $berat = $request->berat[$index] ?? null;
+
+            if ($berat === null || $berat <= 0) {
+                $errors["berat.{$index}"] = 'Berat sampah harus lebih dari 0.';
+                continue;
+            }
+
+            $sampah = Sampah::find($sampahId);
+            if ($sampah && $berat > $sampah->stok) {
+                $errors["berat.{$index}"] = 'Berat penjualan melebihi stok tersedia.';
+            }
+        }
+
+        if (!empty($errors)) {
+            return back()->withErrors($errors)->withInput();
+        }
 
         DB::beginTransaction();
 
@@ -113,7 +126,12 @@ class PenjualanSampahController extends Controller
 
             foreach ($request->sampah_id as $index => $sampahId) {
                 $berat = $request->berat[$index];
-                $sampah = Sampah::findOrFail($sampahId);
+                $sampah = Sampah::where('id', $sampahId)->lockForUpdate()->firstOrFail();
+
+                if ($berat > $sampah->stok) {
+                    throw new \Exception('Stok sampah ' . $sampah->nama_sampah . ' tidak mencukupi.');
+                }
+
                 $subtotal = $berat * $sampah->harga_per_kg;
                 $totalHarga += $subtotal;
 

--- a/app/Http/Controllers/Admin/SetoranController.php
+++ b/app/Http/Controllers/Admin/SetoranController.php
@@ -80,7 +80,7 @@ class SetoranController extends Controller
 
         DB::beginTransaction();
         try {
-            $sampah = Sampah::findOrFail($request->sampah_id);
+            $sampah = Sampah::where('id', $request->sampah_id)->lockForUpdate()->firstOrFail();
             $subtotal = $sampah->harga_per_kg * $request->berat;
 
             $setoran = Setoran::create([

--- a/resources/views/admin/transaksi/penjualan-sampah/create.blade.php
+++ b/resources/views/admin/transaksi/penjualan-sampah/create.blade.php
@@ -7,6 +7,16 @@
         <div class="alert alert-danger mb-4">{{ session('error') }}</div>
     @endif
 
+    @if ($errors->any())
+        <div class="alert alert-danger mb-4">
+            <ul class="mb-0">
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
     <div class="row">
         <div class="col-lg-10">
             <div class="card shadow mb-4">
@@ -54,6 +64,9 @@
                                 <div class="col-md-3">
                                     <label>Berat (kg)</label>
                                     <input type="number" name="berat[]" class="form-control" step="0.01" required>
+                                    @error('berat.0')
+                                        <small class="text-danger">{{ $message }}</small>
+                                    @enderror
                                 </div>
 
                                 <div class="col-md-1 d-flex align-items-end">

--- a/tests/Feature/Admin/PenjualanSampahControllerTest.php
+++ b/tests/Feature/Admin/PenjualanSampahControllerTest.php
@@ -116,6 +116,103 @@ class PenjualanSampahControllerTest extends TestCase
     }
 
     // -----------------------------------------------------------------------
+    // Store — Stock behavior
+    // -----------------------------------------------------------------------
+
+    /** @test */
+    public function penjualan_decreases_sampah_stock(): void
+    {
+        // Arrange
+        $admin    = $this->adminUser();
+        $pengepul = Pengepul::factory()->create();
+        $sampah   = Sampah::factory()->create(['harga_per_kg' => 1000, 'stok' => 10]);
+
+        // Act
+        $this->actingAs($admin)->post(route('admin.penjualan.store'), [
+            'pengepul_id' => $pengepul->id,
+            'sampah_id'   => [$sampah->id],
+            'berat'       => [3],
+        ]);
+
+        // Assert: stock harus berkurang
+        $this->assertEquals(7, $sampah->fresh()->stok);
+    }
+
+    /** @test */
+    public function penjualan_with_zero_berat_fails_validation(): void
+    {
+        // Arrange
+        $admin    = $this->adminUser();
+        $pengepul = Pengepul::factory()->create();
+        $sampah   = Sampah::factory()->create(['harga_per_kg' => 1000, 'stok' => 10]);
+
+        // Act
+        $response = $this->actingAs($admin)->post(route('admin.penjualan.store'), [
+            'pengepul_id' => $pengepul->id,
+            'sampah_id'   => [$sampah->id],
+            'berat'       => [0],
+        ]);
+
+        // Assert: error dengan field spesifik
+        $response->assertSessionHasErrors('berat.0');
+        $this->assertDatabaseCount('penjualan_sampahs', 0);
+        $this->assertDatabaseCount('detail_penjualan_sampahs', 0);
+        // Stock tetap sama
+        $this->assertEquals(10, $sampah->fresh()->stok);
+    }
+
+    /** @test */
+    public function penjualan_with_insufficient_stock_fails_validation(): void
+    {
+        // Arrange
+        $admin    = $this->adminUser();
+        $pengepul = Pengepul::factory()->create();
+        $sampah   = Sampah::factory()->create(['harga_per_kg' => 1000, 'stok' => 10]);
+
+        // Act
+        $response = $this->actingAs($admin)->post(route('admin.penjualan.store'), [
+            'pengepul_id' => $pengepul->id,
+            'sampah_id'   => [$sampah->id],
+            'berat'       => [11],
+        ]);
+
+        // Assert: error dengan field spesifik
+        $response->assertSessionHasErrors('berat.0');
+        $this->assertDatabaseCount('penjualan_sampahs', 0);
+        $this->assertDatabaseCount('detail_penjualan_sampahs', 0);
+        // Stock tetap sama
+        $this->assertEquals(10, $sampah->fresh()->stok);
+    }
+
+    /** @test */
+    public function penjualan_rolls_back_all_changes_when_one_item_exceeds_stock(): void
+    {
+        // Arrange
+        $admin    = $this->adminUser();
+        $pengepul = Pengepul::factory()->create();
+        $sampah1  = Sampah::factory()->create(['harga_per_kg' => 2000, 'stok' => 10]);
+        $sampah2  = Sampah::factory()->create(['harga_per_kg' => 3000, 'stok' => 5]);
+
+        // Act: item 1 valid (5 < 10), item 2 melebihi stok (10 > 5)
+        $response = $this->actingAs($admin)->post(route('admin.penjualan.store'), [
+            'pengepul_id' => $pengepul->id,
+            'sampah_id'   => [$sampah1->id, $sampah2->id],
+            'berat'       => [5, 10],
+        ]);
+
+        // Assert: must fail - either custom validation caught it or transaction rolled back
+        $response->assertSessionHasErrors();
+
+        // Tidak ada satupun penjualan atau detail yang tersimpan
+        $this->assertDatabaseCount('penjualan_sampahs', 0);
+        $this->assertDatabaseCount('detail_penjualan_sampahs', 0);
+
+        // Stock kedua sampah tetap tidak berubah
+        $this->assertEquals(10, $sampah1->fresh()->stok);
+        $this->assertEquals(5, $sampah2->fresh()->stok);
+    }
+
+    // -----------------------------------------------------------------------
     // Store — Validasi
     // -----------------------------------------------------------------------
 

--- a/tests/Feature/Admin/SetoranControllerTest.php
+++ b/tests/Feature/Admin/SetoranControllerTest.php
@@ -43,6 +43,26 @@ class SetoranControllerTest extends TestCase
     }
 
     /** @test */
+    public function setoran_increases_sampah_stock(): void
+    {
+        // Arrange
+        $admin   = $this->adminUser();
+        $nasabah = Nasabah::factory()->withSaldo(0)->create();
+        $sampah  = Sampah::factory()->create(['harga_per_kg' => 2000, 'stok' => 10]);
+
+        // Act
+        $response = $this->actingAs($admin)->post(route('admin.setoran.store'), [
+            'nasabah_id' => $nasabah->id,
+            'sampah_id'  => $sampah->id,
+            'berat'      => 2.5,
+        ]);
+
+        // Assert
+        $response->assertRedirect(route('admin.setoran.index'));
+        $this->assertEquals(12.5, $sampah->fresh()->stok);
+    }
+
+    /** @test */
     public function admin_can_view_setoran_index(): void
     {
         // Arrange


### PR DESCRIPTION
## Changes

### Stock Logic Fixes
- **Setoran (Deposit)**: Stock increment via \sampahs.stok\ with \lockForUpdate()\ for concurrent safety
- **Penjualan (Sales)**: Stock decrement inside DB transaction with \lockForUpdate()\ and race condition re-check
- **Penjualan create()**: Now uses actual \sampahs.stok\ column instead of recalculating from relational aggregates

### Validation
- Server-side validation rejects \erat = 0\ with field-specific error (\Berat sampah harus lebih dari 0.\)
- Server-side validation rejects \erat > stok\ with field-specific error (\Berat penjualan melebihi stok tersedia.\)
- Transaction-level re-check prevents race condition (\Stok sampah tidak mencukupi.\)

### UI
- General validation error alert in penjualan form
- Inline field error display for \erat.0\

### Tests Added
- Setoran: stock increment test (10 → 12.5)
- Penjualan: stock decrement test (10 → 7)
- Penjualan: zero weight validation error test
- Penjualan: insufficient stock validation test
- Penjualan: multi-item rollback test

## Acceptance Criteria Met
- [x] Setoran increases \sampahs.stok\ by submitted \erat\
- [x] Penjualan decreases \sampahs.stok\ by submitted \erat\
- [x] Penjualan with \erat = 0\ fails validation, no records created
- [x] Penjualan with \erat > stok\ fails validation, no records created
- [x] Failed penjualan does not change any stock values (transaction rollback)
- [x] \lockForUpdate()\ prevents race conditions for concurrent requests
- [x] Tests cover stock increment, decrement, zero weight, insufficient stock, and rollback